### PR TITLE
Fix non returning pendulum orbits

### DIFF
--- a/src/Hamiltonians/include/Hamiltonian.hpp
+++ b/src/Hamiltonians/include/Hamiltonian.hpp
@@ -102,6 +102,13 @@ namespace Integrators
           {
             return analytical_action(value(s));
           }
+
+          double kappa(const Geometry::State2& s) const
+          {
+            const auto energy = value(s);
+            const auto kappa_square = 0.5 * two_kappa_square(energy);
+            return std::sqrt(kappa_square);
+          }
         };
 
         class FreeParticle

--- a/src/Hamiltonians/include/Integration.hpp
+++ b/src/Hamiltonians/include/Integration.hpp
@@ -277,7 +277,7 @@ namespace Integrators
 
       auto observer = Integrators::make_project_on_line_observer(system, cross_line, [] (auto&)
       { return true; });
-      observe(observer, integration_range);
+      cross(observer, integration_range);
 
       return observer.observations();
     }
@@ -302,7 +302,7 @@ namespace Integrators
       auto observer = Integrators::make_project_on_periodic_Q_observer(system, periodicQSurfaceCrossObserver, [] (auto&)
       { return true; });
 
-      observe(observer, integration_range);
+      cross(observer, integration_range);
 
       return observer.observations();
     }
@@ -327,7 +327,7 @@ namespace Integrators
       auto observer = Integrators::make_project_on_line_observer(system, cross_line, [] (auto&)
       { return true; });
 
-      observe_if(observer, integration_range);
+      cross_once(observer, integration_range);
 
       const auto observations = observer.observations();
 
@@ -353,7 +353,7 @@ namespace Integrators
                                                                                         integrationTime,
                                                                                         options);
 
-      observe_if(observer, integration_range);
+      cross_once(observer, integration_range);
 
       const auto observations = observer.observations();
 
@@ -362,7 +362,7 @@ namespace Integrators
 
       return observations.front();
 
-    };
+    }
 
     template<typename Ham>
     Geometry::State2_Extended

--- a/src/Hamiltonians/include/action_angle.hpp
+++ b/src/Hamiltonians/include/action_angle.hpp
@@ -9,15 +9,17 @@
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/algorithm_ext/push_back.hpp>
 
-
-
 #include "State.hpp"
 #include "Integration.hpp"
 #include "myUtilities/myUtilities.hpp"
 
-
 namespace Integrators
 {
+
+    struct AnglesPositions {
+        std::vector<double> theta{};
+        std::vector<Geometry::State2> positions{};
+    };
 
     class ActionAngleOrbit {
       double action_two_pi_{};
@@ -26,11 +28,17 @@ namespace Integrators
       std::vector<Geometry::State2> positions_{};
 
      public:
-      ActionAngleOrbit()= default;
+      ActionAngleOrbit () = default;
       ActionAngleOrbit (double action_two_pi,
                         double omega,
                         const std::vector<double>& theta,
                         const std::vector<Geometry::State2>& positions);
+
+      ActionAngleOrbit (double action_two_pi, double omega, AnglesPositions anglesPositions);
+
+      ActionAngleOrbit (double action_two_pi, double omega, AnglesPositions&& anglesPositions);
+
+
       double action_two_pi () const;
       double omega () const;
       const std::vector<double>& theta () const;
@@ -39,6 +47,25 @@ namespace Integrators
         return positions_;
       }
     };
+
+    template<typename Ham>
+    AnglesPositions map_positions_to_angles_along_orbit (Ham hamiltonian,
+                                                         Geometry::State2 s_start,
+                                                         double orbit_completion_time,
+                                                         const IntegrationOptions& options,
+                                                         size_t number_of_angles)
+    {
+      auto times = PanosUtilities::linspace(0.0, orbit_completion_time, number_of_angles);
+
+      auto orbit_range = make_interval_range(Dynamics::DynamicSystem(hamiltonian), s_start, times, options);
+
+      std::vector<Geometry::State2> positions{};
+      boost::push_back(positions, orbit_range | boost::adaptors::transformed([] (const auto& p)
+                                                                             { return p.first; }));
+
+      return AnglesPositions{PanosUtilities::linspace(0.0, boost::math::double_constants::two_pi, number_of_angles),
+                             positions};
+    }
 
     template<typename Ham>
     ActionAngleOrbit calculate_action_angle_on_closed_orbit (Ham hamiltonian,
@@ -51,53 +78,44 @@ namespace Integrators
       const auto s_out_extended = come_back_home_closed_orbit(hamiltonian, s_start, integrationTime, options);
 
       const auto action = s_out_extended.J();
-      const auto omega = boost::math::double_constants::two_pi / s_out_extended.t();
+      const auto period = s_out_extended.t();
+      const auto omega = boost::math::double_constants::two_pi / period;
 
-      Geometry::State2 s2 = s_start;
+      const auto anglesPositions = map_positions_to_angles_along_orbit(hamiltonian,
+                                                                       s_start,
+                                                                       period,
+                                                                       options,
+                                                                       number_of_angles);
 
-      auto times = PanosUtilities::linspace(0.0, s_out_extended.t(), number_of_angles);
 
-      auto orbit_range = make_interval_range(Dynamics::DynamicSystem(hamiltonian), s2, times, options);
-
-      std::vector<Geometry::State2> positions{};
-      boost::push_back(positions, orbit_range | boost::adaptors::transformed([] (const auto& p)
-                                                                             { return p.first; }));
-
-      const auto theta = PanosUtilities::linspace(0.0, boost::math::double_constants::two_pi, number_of_angles);
-
-      return ActionAngleOrbit{action, omega, theta, std::move(positions)};
+      return ActionAngleOrbit{action, omega, anglesPositions};
 
     }
 
     template<typename Ham>
     ActionAngleOrbit calculate_action_angle_on_periodic_orbit (Ham hamiltonian,
-                                                             const Geometry::State2& s_start,
-                                                             const TimeInterval& integrationTime,
-                                                             const IntegrationOptions& options,
-                                                             size_t number_of_angles = 100)
+                                                               const Geometry::State2& s_start,
+                                                               const TimeInterval& integrationTime,
+                                                               const IntegrationOptions& options,
+                                                               size_t number_of_angles = 100)
     {
 
       const auto s_out_extended = come_back_home_periodic_orbit(hamiltonian, s_start, integrationTime, options);
 
       const auto action = s_out_extended.J();
-      const auto omega = boost::math::double_constants::two_pi / s_out_extended.t();
+      const auto period = s_out_extended.t();
+      const auto omega = boost::math::double_constants::two_pi / period;
 
-      Geometry::State2 s2 = s_start;
+      const auto anglesPositions = map_positions_to_angles_along_orbit(hamiltonian,
+                                                                       s_start,
+                                                                       period,
+                                                                       options,
+                                                                       number_of_angles);
 
-      auto times = PanosUtilities::linspace(0.0, s_out_extended.t(), number_of_angles);
 
-      auto orbit_range = make_interval_range(Dynamics::DynamicSystem(hamiltonian), s2, times, options);
-
-      std::vector<Geometry::State2> positions{};
-      boost::push_back(positions, orbit_range | boost::adaptors::transformed([] (const auto& p)
-                                                                             { return p.first; }));
-
-      const auto theta = PanosUtilities::linspace(0.0, boost::math::double_constants::two_pi, number_of_angles);
-
-      return ActionAngleOrbit{action, omega, theta, std::move(positions)};
+      return ActionAngleOrbit{action, omega, anglesPositions};
 
     }
-
 
 }
 #endif //HAMILTONIANS_ACTION_ANGLE_HPP

--- a/src/Hamiltonians/include/observer.hpp
+++ b/src/Hamiltonians/include/observer.hpp
@@ -113,7 +113,7 @@ namespace Integrators
         /// \param integration_range
 
         template<typename Observer, typename IntegrationRange>
-        void observe (Observer& observer, const IntegrationRange& integration_range)
+        void cross (Observer& observer, const IntegrationRange& integration_range)
         {
           for (const auto& s_t: integration_range)
             observer(s_t);
@@ -127,7 +127,7 @@ namespace Integrators
         /// \param observer
         /// \param integration_range
         template<typename Observer, typename IntegrationRange>
-        void observe_if (Observer& observer, const IntegrationRange& integration_range)
+        void cross_once (Observer& observer, const IntegrationRange& integration_range)
         {
 
           boost::range::find_if(integration_range, std::ref(observer));

--- a/src/Hamiltonians/src/Integration.cpp
+++ b/src/Hamiltonians/src/Integration.cpp
@@ -92,29 +92,36 @@ namespace Integrators
 
     template
     Geometry::State2_Extended
-    come_back_home<Hamiltonian::FreeParticle> (const Hamiltonian::FreeParticle& hamiltonian,
+    come_back_home_closed_orbit<Hamiltonian::FreeParticle> (const Hamiltonian::FreeParticle& hamiltonian,
                                                const Geometry::State2& s_start,
                                                const TimeInterval& integrationTime,
                                                const IntegrationOptions& options);
 
     template
     Geometry::State2_Extended
-    come_back_home<Hamiltonian::HarmonicOscillator> (const Hamiltonian::HarmonicOscillator& hamiltonian,
+    come_back_home_closed_orbit<Hamiltonian::HarmonicOscillator> (const Hamiltonian::HarmonicOscillator& hamiltonian,
                                                      const Geometry::State2& s_start,
                                                      const TimeInterval& integrationTime,
                                                      const IntegrationOptions& options);
     template
     Geometry::State2_Extended
-    come_back_home<Hamiltonian::PendulumHamiltonian> (const Hamiltonian::PendulumHamiltonian& hamiltonian,
+    come_back_home_closed_orbit<Hamiltonian::PendulumHamiltonian> (const Hamiltonian::PendulumHamiltonian& hamiltonian,
                                                       const Geometry::State2& s_start,
                                                       const TimeInterval& integrationTime,
                                                       const IntegrationOptions& options);
     template
     Geometry::State2_Extended
-    come_back_home<Hamiltonian::DuffingHamiltonian> (const Hamiltonian::DuffingHamiltonian& hamiltonian,
+    come_back_home_closed_orbit<Hamiltonian::DuffingHamiltonian> (const Hamiltonian::DuffingHamiltonian& hamiltonian,
                                                      const Geometry::State2& s_start,
                                                      const TimeInterval& integrationTime,
                                                      const IntegrationOptions& options);
+
+    template
+    Geometry::State2_Extended
+    come_back_home_periodic_orbit (const Hamiltonian::PendulumHamiltonian& hamiltonian,
+                                   const Geometry::State2& s_start,
+                                   const TimeInterval& integrationTime,
+                                   const IntegrationOptions& options);
 
 
 

--- a/src/Hamiltonians/src/action_angle.cpp
+++ b/src/Hamiltonians/src/action_angle.cpp
@@ -22,4 +22,20 @@ namespace Integrators
     {
       return theta_;
     }
+    ActionAngleOrbit::ActionAngleOrbit (double action_two_pi, double omega, AnglesPositions anglesPositions)
+        : action_two_pi_(action_two_pi),
+          omega_(omega),
+          theta_{std::move(anglesPositions.theta)},
+          positions_{std::move(anglesPositions.positions)}
+    {
+
+    }
+    ActionAngleOrbit::ActionAngleOrbit (double action_two_pi, double omega, AnglesPositions&& anglesPositions)
+        : action_two_pi_(action_two_pi),
+          omega_(omega),
+          theta_{anglesPositions.theta},
+          positions_{anglesPositions.positions}
+    {
+
+    }
 }

--- a/src/examples/pendulum_example.cpp
+++ b/src/examples/pendulum_example.cpp
@@ -85,7 +85,7 @@ ActionResult calculate_action(const State2& s_init)
 int main ()
 {
 
-  const auto x_init_vals = PanosUtilities::linspace(0.01,boost::math::double_constants::pi  ,30);
+  const auto x_init_vals = PanosUtilities::linspace(0.01,boost::math::double_constants::pi  ,300);
 
   std::vector<ActionResult> action_result_vector;
 

--- a/src/examples/pendulum_example.cpp
+++ b/src/examples/pendulum_example.cpp
@@ -39,7 +39,8 @@ ActionResult calculate_action(const State2& s_init)
   result.energy = hamiltonian.value(s_init);
 
 
-  const IntegrationOptions options;
+  IntegrationOptions options;
+  options.set_distance_threshold(1e-9);
 
   const auto integrationTime = Integrators::TimeInterval{0.0,1000};
 

--- a/src/examples/pendulum_example.cpp
+++ b/src/examples/pendulum_example.cpp
@@ -41,16 +41,25 @@ ActionResult calculate_action(const State2& s_init)
 
   const IntegrationOptions options;
 
-  const auto integrationTime = Integrators::TimeInterval{0.0,100};
+  const auto integrationTime = Integrators::TimeInterval{0.0,1000};
 
 
   State2 s1= s_init;
-  
-  const auto actionAngleOrbit = calculate_action_angle_on_closed_orbit(hamiltonian,s1,integrationTime,options,2);
+  try
+    {
+      const auto actionAngleOrbit = calculate_action_angle_on_closed_orbit(hamiltonian, s1, integrationTime, options, 2);
 
-  result.numerical_action = actionAngleOrbit.action_two_pi()*boost::math::double_constants::one_div_two_pi;
-  result.omega = actionAngleOrbit.omega();
+      result.numerical_action = actionAngleOrbit.action_two_pi() * boost::math::double_constants::one_div_two_pi;
+      result.omega = actionAngleOrbit.omega();
+    }
+  catch (std::exception & e)
+    {
+      std::cout<<e.what()<<'\n';
+      std::cout<<"At orbit starting from point "<< s_init<<'\n';
+      result.numerical_action=std::nan("");
+      result.omega=std::nan("");
 
+    }
   return result;
 
 }
@@ -58,11 +67,11 @@ ActionResult calculate_action(const State2& s_init)
 int main ()
 {
 
-  const auto x_init_vals = PanosUtilities::linspace(0.5,0.9,30);
+  const auto x_init_vals = PanosUtilities::linspace(0.01,boost::math::double_constants::pi,30);
 
   std::vector<ActionResult> action_result_vector;
 
-  boost::push_back(action_result_vector, x_init_vals | boost::adaptors::transformed( [](auto x){return calculate_action(State2{x,0.8});}));
+  boost::push_back(action_result_vector, x_init_vals | boost::adaptors::transformed( [](auto x){return calculate_action(State2{x,0});}));
 
   std::cout<<"engergy\tanalytical_action\tnumerical_action\tomega\n";
   for (const auto& a_r: action_result_vector)
@@ -72,6 +81,17 @@ int main ()
         << a_r.omega<<'\n';
 
 
+  auto times = PanosUtilities::linspace(0.0, 10, 1000);
+
+  auto s_escaping_init = Geometry::State2{1.62979, 0};
+  auto orbit_range = make_interval_range(Dynamics::DynamicSystem(Hamiltonian::PendulumHamiltonian{1, 1}),
+                                         s_escaping_init, times, Integrators::IntegrationOptions{});
+
+  std::ofstream output("not_retunring.txt");
+
+  output<< "not returning orbit\n";
+  for (const auto & s: orbit_range)
+    output<<s.first<<'\n';
 //  for ( const auto s_t : boost::range::combine(actionAngleOrbit.positions(),actionAngleOrbit.theta()))
 //    {
 //      double theta;


### PR DESCRIPTION
In the pendulum example, orbits that should be closed, throw complaining that they never did.
By increasing the distance_threshold in options, this seems to be fixed.

Maybe the default distance threshold is too small and we should consider increasing it.
